### PR TITLE
Update packages and the target environment for the test project.

### DIFF
--- a/build/azDevOps/packages-amido-stacks-configuration.yml
+++ b/build/azDevOps/packages-amido-stacks-configuration.yml
@@ -66,7 +66,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
+      name: Ensono/stacks-pipeline-templates
       ref: refs/tags/v2.0.1
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks

--- a/build/azDevOps/packages-amido-stacks-configuration.yml
+++ b/build/azDevOps/packages-amido-stacks-configuration.yml
@@ -67,7 +67,7 @@ resources:
     - repository: templates
       type: github
       name: Ensono/stacks-pipeline-templates
-      ref: refs/tags/v2.0.1
+      ref: refs/heads/feature/cycle4
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
   containers:
@@ -81,7 +81,7 @@ stages:
     jobs:
       - job: Validation
         pool:
-          vmImage: "ubuntu-18.04"
+          vmImage: "ubuntu-22.04"
         steps:
           - checkout: self
 
@@ -121,4 +121,4 @@ stages:
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "3.1.x"
+              dotnet_core_version: "6.0.x"

--- a/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
+++ b/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
+++ b/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Testing" Version="0.2.20" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
+++ b/src/Amido.Stacks.Configuration.Tests/Amido.Stacks.Configuration.Tests.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+    <PackageReference Include="Amido.Stacks.Testing" Version="0.2.29" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Amido.Stacks.Configuration/Amido.Stacks.Configuration.csproj
+++ b/src/Amido.Stacks.Configuration/Amido.Stacks.Configuration.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
+    <PackageReference Include="Amido.Stacks.Core" Version="0.2.35" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Amido.Stacks.Configuration/Amido.Stacks.Configuration.csproj
+++ b/src/Amido.Stacks.Configuration/Amido.Stacks.Configuration.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Core" Version="0.2.19" />
+    <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update packages and the target environment for the test project.

#### 📲 What
Updating packages to their latest long term support release. In this case, Amido.Stacks.Core has been updated from v.02.19 to 0.2.35.  Various testing packages used in the Amido.Stacks.Configuration.Tests project have also been updated along with the target framework,. It was previously 'net472;netcoreapp3.1', but it has been updated to net472;net6.0 because netcoreapp3.1 is no longer supported.

### 🤔 Why
Packages updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

### 🛠 How
Simple package updates in the csproj files and an update to the TargetFramework property in the in the Amido.Stacks.Configuration.Tests.csproj file.

### 👀 Evidence
* See the Amido.Stacks.Configuration.csproj and  Amido.Stacks.Configuration.Tests.csproj file for version increases.
* All automated tests still pass.

### 🕵️ How to test
Notes for QA

✅ Acceptance criteria Checklist
 Code peer reviewed?
 Documentation has been updated to reflect the changes?
 Passing all automated tests, including a successful deployment?
 Passing any exploratory testing?
 Rebased/merged with latest changes from development and re-tested?
 Meeting the Coding Standards?